### PR TITLE
Changed SOLR_VERSION to 4.10.4 in solr/Dockerfile

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -5,7 +5,7 @@
 FROM    makuk66/docker-oracle-java7
 MAINTAINER MLstate <contact@mlstate.com>
 
-ENV SOLR_VERSION 4.10.3
+ENV SOLR_VERSION 4.10.4
 ENV SOLR solr-$SOLR_VERSION
 RUN export DEBIAN_FRONTEND=noninteractive && \
   apt-get update && \


### PR DESCRIPTION
This was causing the installation to fail because the version 4.10.3 doesn't exist in http://www.mirrorservice.org/sites/ftp.apache.org/lucene/solr/ anymore.