### PR TITLE
Update Dockerfiles to use node 0.10* friendly versions of NPM modules.

### DIFF
--- a/peps/Dockerfile
+++ b/peps/Dockerfile
@@ -14,14 +14,14 @@ RUN /usr/bin/npm install -g \
   ursa \
   simplesmtp \
   rai \
-  nodemailer \
+  nodemailer@2.7.2 \
   ldapjs \
   iconv \
-  nodemailer-smtp-transport \
-  mailparser \
+  nodemailer-smtp-transport@2.7.2 \
+  mailparser@0.6.2 \
   html-to-text \
   tweetnacl@0.13.3 \
-  intl-messageformat intl
+  intl-messageformat intl@0.1.4
 
 # We need to add the webmail modules to the node path
 ENV NODE_PATH $NODE_PATH:/peps/_build

--- a/smtpin/Dockerfile
+++ b/smtpin/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 VOLUME ["/etc/peps"]
 
 # Install Haraka
-RUN npm install -g Haraka
+RUN npm install -g Haraka@1.4.0
 RUN haraka -i /usr/local/haraka
 
 # Configure domain name

--- a/smtpout/Dockerfile
+++ b/smtpout/Dockerfile
@@ -14,7 +14,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q install nodejs
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Haraka
-RUN npm install -g Haraka
+RUN npm install -g Haraka@1.4.0
 RUN haraka -i /usr/local/haraka
 
 # Configure domain


### PR DESCRIPTION
PEPS Should be updated to work with an up to date version of node and up to date node modules for security reasons. However this PR fixes npm module version mismatches and targets node 0.10 friendly versions of modules.   